### PR TITLE
Remove a quipper directory prefix in one of the includes in a source file present in quipper directory.

### DIFF
--- a/quipper/binary_data_utils.cc
+++ b/quipper/binary_data_utils.cc
@@ -10,7 +10,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
-#include <fstream>  // NOLINT(readability/streams)
+#include <fstream>  
 #include <iomanip>
 
 #include "base/logging.h"
@@ -27,7 +27,7 @@ namespace quipper {
 
 static uint64_t Md5Prefix(
     const unsigned char* data,
-    unsigned long length) { // NOLINT
+    unsigned long length) { 
   uint64_t digest_prefix = 0;
   unsigned char digest[MD5_DIGEST_LENGTH + 1];
 

--- a/quipper/compat/cros/detail/proto.h
+++ b/quipper/compat/cros/detail/proto.h
@@ -12,8 +12,8 @@
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
 
-#include "perf_data.pb.h"  // NOLINT(build/include)
-#include "perf_stat.pb.h"  // NOLINT(build/include)
+#include "perf_data.pb.h"  
+#include "perf_stat.pb.h"  
 
 namespace quipper {
 

--- a/quipper/huge_page_deducer_test.cc
+++ b/quipper/huge_page_deducer_test.cc
@@ -1,4 +1,4 @@
-#include "quipper/huge_page_deducer.h"
+#include "huge_page_deducer.h"  
 
 #include "compat/test.h"
 

--- a/quipper/mybase/base/logging.h
+++ b/quipper/mybase/base/logging.h
@@ -8,7 +8,7 @@
 #include <errno.h>   // for errno
 #include <string.h>  // for strerror
 
-#include <iostream>  // NOLINT(readability/streams)
+#include <iostream>  
 #include <sstream>
 #include <string>
 

--- a/quipper/test_perf_data.cc
+++ b/quipper/test_perf_data.cc
@@ -7,7 +7,7 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <ostream>  // NOLINT
+#include <ostream>  
 #include <vector>
 
 #include "base/logging.h"
@@ -43,7 +43,7 @@ void SwapBitfieldOfBits(u8* field, size_t len) {
 }  // namespace
 
 ExamplePerfDataFileHeader::ExamplePerfDataFileHeader(
-    const unsigned long features) {  // NOLINT
+    const unsigned long features) {  
   CHECK_EQ(112U, sizeof(perf_file_attr)) << "perf_file_attr has changed size!";
   header_ = {
     .magic = kPerfMagic,

--- a/quipper/test_perf_data.h
+++ b/quipper/test_perf_data.h
@@ -6,7 +6,7 @@
 #define CHROMIUMOS_WIDE_PROFILING_TEST_PERF_DATA_H_
 
 #include <memory>
-#include <ostream>  // NOLINT
+#include <ostream>  
 #include <vector>
 
 #include "binary_data_utils.h"
@@ -70,7 +70,7 @@ class StreamWriteable {
 class ExamplePerfDataFileHeader : public StreamWriteable {
  public:
   typedef ExamplePerfDataFileHeader SelfT;
-  explicit ExamplePerfDataFileHeader(const unsigned long features);  // NOLINT
+  explicit ExamplePerfDataFileHeader(const unsigned long features);  
 
   SelfT& WithAttrIdsCount(size_t n);
   SelfT& WithAttrCount(size_t n);


### PR DESCRIPTION
PiperOrigin-RevId: 170499000