### PR TITLE
Remove quadratic iteration over attrs for piped perf.data.

### DIFF
--- a/quipper/perf_reader.cc
+++ b/quipper/perf_reader.cc
@@ -1120,7 +1120,7 @@ bool PerfReader::ReadEventDescMetadata(DataReader* data, u32 type,
     return false;
   }
 
-  attrs_seen_.clear();
+  file_attrs_seen_.clear();
   proto_->clear_file_attrs();
   proto_->mutable_file_attrs()->Reserve(nr_events);
 
@@ -1742,7 +1742,8 @@ bool PerfReader::ReadAttrEventBlock(DataReader* data, size_t size) {
 
   // Event types are found many times in the perf data file.
   // Only add this event type if it is not already present.
-  if (!attr.ids.empty() && attrs_seen_.find(attr.ids[0]) != attrs_seen_.end()) {
+  if (!attr.ids.empty() &&
+      file_attrs_seen_.find(attr.ids[0]) != file_attrs_seen_.end()) {
     return true;
   }
 
@@ -1948,7 +1949,7 @@ void PerfReader::AddPerfFileAttr(const PerfFileAttr& attr) {
   // Generate a new SampleInfoReader with the new attr.
   serializer_.CreateSampleInfoReader(attr, is_cross_endian_);
   if (!attr.ids.empty()) {
-    attrs_seen_.insert(attr.ids[0]);
+    file_attrs_seen_.insert(attr.ids[0]);
   }
 }
 

--- a/quipper/perf_reader.cc
+++ b/quipper/perf_reader.cc
@@ -1120,6 +1120,7 @@ bool PerfReader::ReadEventDescMetadata(DataReader* data, u32 type,
     return false;
   }
 
+  attrs_seen_.clear();
   proto_->clear_file_attrs();
   proto_->mutable_file_attrs()->Reserve(nr_events);
 
@@ -1741,10 +1742,10 @@ bool PerfReader::ReadAttrEventBlock(DataReader* data, size_t size) {
 
   // Event types are found many times in the perf data file.
   // Only add this event type if it is not already present.
-  for (const auto& stored_attr : proto_->file_attrs()) {
-    if (stored_attr.ids(0) == attr.ids[0])
-      return true;
+  if (!attr.ids.empty() && attrs_seen_.find(attr.ids[0]) != attrs_seen_.end()) {
+    return true;
   }
+
   AddPerfFileAttr(attr);
   return true;
 }
@@ -1946,6 +1947,9 @@ void PerfReader::AddPerfFileAttr(const PerfFileAttr& attr) {
 
   // Generate a new SampleInfoReader with the new attr.
   serializer_.CreateSampleInfoReader(attr, is_cross_endian_);
+  if (!attr.ids.empty()) {
+    attrs_seen_.insert(attr.ids[0]);
+  }
 }
 
 }  // namespace quipper

--- a/quipper/perf_reader.h
+++ b/quipper/perf_reader.h
@@ -11,8 +11,8 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <vector>
 #include <unordered_set>
+#include <vector>
 
 #include "base/macros.h"
 

--- a/quipper/perf_reader.h
+++ b/quipper/perf_reader.h
@@ -12,6 +12,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include "base/macros.h"
 
@@ -262,6 +263,8 @@ class PerfReader {
   // Store the perf data as a protobuf.
   Arena arena_;
   PerfDataProto* proto_;
+  // Attribute ids that have been added to |proto_|, for deduplication.
+  std::unordered_set<u64> attrs_seen_;
 
   // Whether the incoming data is from a machine with a different endianness. We
   // got rid of this flag in the past but now we need to store this so it can be

--- a/quipper/perf_reader.h
+++ b/quipper/perf_reader.h
@@ -264,7 +264,7 @@ class PerfReader {
   Arena arena_;
   PerfDataProto* proto_;
   // Attribute ids that have been added to |proto_|, for deduplication.
-  std::unordered_set<u64> attrs_seen_;
+  std::unordered_set<u64> file_attrs_seen_;
 
   // Whether the incoming data is from a machine with a different endianness. We
   // got rid of this flag in the past but now we need to store this so it can be


### PR DESCRIPTION
Instead, deduplicate with a set.

PiperOrigin-RevId: 171340043