### PR TITLE
Pull upstream changes

### DIFF
--- a/src/quipper/perf_serializer.cc
+++ b/src/quipper/perf_serializer.cc
@@ -1057,10 +1057,11 @@ bool PerfSerializer::SerializeAuxtraceErrorEvent(
         << "contains a non-zero value: " << auxtrace_error.reserved__ << ". "
         << "This record's format has changed.";
   }
-  u16 len = strnlen(auxtrace_error.msg,
-                    std::min((u64)MAX_AUXTRACE_ERROR_MSG,
-                             auxtrace_error.header.size -
-                                 offsetof(struct auxtrace_error_event, msg)));
+  size_t len =
+      strnlen(auxtrace_error.msg,
+              std::min<size_t>(MAX_AUXTRACE_ERROR_MSG,
+                               (auxtrace_error.header.size -
+                                offsetof(struct auxtrace_error_event, msg))));
   sample->set_msg(auxtrace_error.msg, len);
   sample->set_msg_md5_prefix(Md5Prefix(sample->msg()));
   return true;

--- a/src/quipper/sample_info_reader.cc
+++ b/src/quipper/sample_info_reader.cc
@@ -662,7 +662,7 @@ uint64_t SampleInfoReader::GetSampleFieldsForEventType(uint32_t event_type,
 
 // static
 uint64_t SampleInfoReader::GetPerfSampleDataOffset(const event_t& event) {
-  uint64_t offset = [&] {
+  uint64_t offset = [&]() -> uint64_t {
     switch (event.header.type) {
       case PERF_RECORD_SAMPLE:
         return offsetof(event_t, sample.array);
@@ -714,7 +714,7 @@ uint64_t SampleInfoReader::GetPerfSampleDataOffset(const event_t& event) {
 // static
 uint64_t SampleInfoReader::GetPerfSampleDataOffset(
     const PerfDataProto_PerfEvent& event) {
-  uint64_t offset = [&] {
+  uint64_t offset = [&]() -> uint64_t {
     switch (event.header().type()) {
       case PERF_RECORD_SAMPLE:
         return offsetof(struct sample_event, array);


### PR DESCRIPTION
Add explicit return type when a lambda expression returns values of different types.

Call std::min with values of the same type across different platforms.

PiperOrigin-RevId: 224583607