### PR TITLE
Use the correct header size to validate the header.size value.

### DIFF
--- a/src/quipper/perf_reader.cc
+++ b/src/quipper/perf_reader.cc
@@ -159,15 +159,15 @@ bool ReadPerfEventHeader(DataReader* data, struct perf_event_header* header) {
     ByteSwap(&header->size);
     ByteSwap(&header->misc);
   }
-  if (header->size < sizeof(header)) {
+  if (header->size < sizeof(*header)) {
     LOG(ERROR) << "Event size " << header->size << " of event "
                << GetEventName(header->type) << " is less than header size "
-               << sizeof(header);
+               << sizeof(*header);
     return false;
   }
   size_t remaining_size = data->size() - data->Tell();
-  if (header->size - sizeof(header) > remaining_size) {
-    LOG(ERROR) << "Remaining event size " << header->size - sizeof(header)
+  if (header->size - sizeof(*header) > remaining_size) {
+    LOG(ERROR) << "Payload size " << header->size - sizeof(*header)
                << " of event " << GetEventName(header->type)
                << " cannot be greater than remaining perf data input size "
                << remaining_size;


### PR DESCRIPTION
Currently, the header pointer size is used instead of the actual header size to validate the header.size value. This
works in 64-bit machines as the header size is 8 bytes. But this bug was detected when the Quipper unit tests broke in 32-bit CrOS machines.

PiperOrigin-RevId: 239830457