### PR TITLE
Remove support for the PERF_RECORD_READ perf event.

### DIFF
--- a/src/quipper/perf_data.proto
+++ b/src/quipper/perf_data.proto
@@ -435,6 +435,8 @@ message PerfDataProto {
 
   // Next tag: 8
   message ReadEvent {
+    option deprecated = true;
+
     // Process ID.
     optional uint32 pid = 1;
 
@@ -720,7 +722,7 @@ message PerfDataProto {
       ForkEvent exit_event = 9;
       LostEvent lost_event = 6;
       ThrottleEvent throttle_event = 7;
-      ReadEvent read_event = 8;
+      ReadEvent read_event = 8 [deprecated=true];
       AuxEvent aux_event = 11;
       ItraceStartEvent itrace_start_event = 13;
       LostSamplesEvent lost_samples_event = 14;

--- a/src/quipper/perf_data_utils.cc
+++ b/src/quipper/perf_data_utils.cc
@@ -113,8 +113,6 @@ const PerfDataProto_SampleInfo* GetSampleInfoForEvent(
     case PERF_RECORD_THROTTLE:
     case PERF_RECORD_UNTHROTTLE:
       return &event.throttle_event().sample_info();
-    case PERF_RECORD_READ:
-      return &event.read_event().sample_info();
     case PERF_RECORD_AUX:
       return &event.aux_event().sample_info();
     case PERF_RECORD_ITRACE_START:
@@ -288,9 +286,6 @@ bool GetEventDataFixedPayloadSize(uint32_t type, size_t* size) {
     case PERF_RECORD_UNTHROTTLE:
       *size = sizeof(struct throttle_event);
       return true;
-    case PERF_RECORD_READ:
-      *size = sizeof(struct read_event);
-      return true;
     case PERF_RECORD_SAMPLE:
       *size = offsetof(struct sample_event, array);
       return true;
@@ -401,7 +396,6 @@ bool GetEventDataVariablePayloadSize(const event_t& event,
     case PERF_RECORD_FORK:
     case PERF_RECORD_THROTTLE:
     case PERF_RECORD_UNTHROTTLE:
-    case PERF_RECORD_READ:
     case PERF_RECORD_SAMPLE:
     case PERF_RECORD_AUX:
     case PERF_RECORD_ITRACE_START:
@@ -552,7 +546,6 @@ bool GetEventDataVariablePayloadSize(const PerfDataProto_PerfEvent& event,
     case PERF_RECORD_FORK:
     case PERF_RECORD_THROTTLE:
     case PERF_RECORD_UNTHROTTLE:
-    case PERF_RECORD_READ:
     case PERF_RECORD_SAMPLE:
     case PERF_RECORD_AUX:
     case PERF_RECORD_ITRACE_START:

--- a/src/quipper/perf_parser.cc
+++ b/src/quipper/perf_parser.cc
@@ -246,7 +246,6 @@ bool PerfParser::ProcessEvents() {
       case PERF_RECORD_LOST:
       case PERF_RECORD_THROTTLE:
       case PERF_RECORD_UNTHROTTLE:
-      case PERF_RECORD_READ:
       case PERF_RECORD_AUX:
       case PERF_RECORD_ITRACE_START:
       case PERF_RECORD_LOST_SAMPLES:

--- a/src/quipper/perf_reader.cc
+++ b/src/quipper/perf_reader.cc
@@ -265,14 +265,6 @@ bool ByteSwapEventDataFixedPayloadFields(event_t* event) {
       ByteSwap(&event->throttle.id);
       ByteSwap(&event->throttle.stream_id);
       return true;
-    case PERF_RECORD_READ:
-      ByteSwap(&event->read.pid);
-      ByteSwap(&event->read.tid);
-      ByteSwap(&event->read.value);
-      ByteSwap(&event->read.time_enabled);
-      ByteSwap(&event->read.time_running);
-      ByteSwap(&event->read.id);
-      return true;
     case PERF_RECORD_AUX:
       ByteSwap(&event->aux.aux_offset);
       ByteSwap(&event->aux.aux_size);
@@ -390,7 +382,6 @@ bool ByteSwapEventDataVariablePayloadFields(event_t* event) {
     case PERF_RECORD_LOST:
     case PERF_RECORD_THROTTLE:
     case PERF_RECORD_UNTHROTTLE:
-    case PERF_RECORD_READ:
     case PERF_RECORD_SAMPLE:
     case PERF_RECORD_AUX:
     case PERF_RECORD_ITRACE_START:

--- a/src/quipper/perf_serializer.cc
+++ b/src/quipper/perf_serializer.cc
@@ -36,7 +36,6 @@ bool PerfSerializer::IsSupportedKernelEventType(uint32_t type) {
     case PERF_RECORD_THROTTLE:
     case PERF_RECORD_UNTHROTTLE:
     case PERF_RECORD_FORK:
-    case PERF_RECORD_READ:
     case PERF_RECORD_SAMPLE:
     case PERF_RECORD_MMAP2:
     case PERF_RECORD_AUX:
@@ -336,8 +335,6 @@ bool PerfSerializer::SerializeKernelEvent(
     case PERF_RECORD_UNTHROTTLE:
       return SerializeThrottleEvent(event,
                                     event_proto->mutable_throttle_event());
-    case PERF_RECORD_READ:
-      return SerializeReadEvent(event, event_proto->mutable_read_event());
     case PERF_RECORD_AUX:
       return SerializeAuxEvent(event, event_proto->mutable_aux_event());
     case PERF_RECORD_ITRACE_START:
@@ -458,8 +455,6 @@ bool PerfSerializer::DeserializeKernelEvent(
     case PERF_RECORD_THROTTLE:
     case PERF_RECORD_UNTHROTTLE:
       return DeserializeThrottleEvent(event_proto.throttle_event(), event);
-    case PERF_RECORD_READ:
-      return DeserializeReadEvent(event_proto.read_event(), event);
     case PERF_RECORD_AUX:
       return DeserializeAuxEvent(event_proto.aux_event(), event);
     case PERF_RECORD_ITRACE_START:
@@ -767,32 +762,6 @@ bool PerfSerializer::DeserializeThrottleEvent(
   throttle.stream_id = sample.stream_id();
 
   return DeserializeSampleInfo(sample.sample_info(), event);
-}
-
-bool PerfSerializer::SerializeReadEvent(const event_t& event,
-                                        PerfDataProto_ReadEvent* sample) const {
-  const struct read_event& read = event.read;
-  sample->set_pid(read.pid);
-  sample->set_tid(read.tid);
-  sample->set_value(read.value);
-  sample->set_time_enabled(read.time_enabled);
-  sample->set_time_running(read.time_running);
-  sample->set_id(read.id);
-
-  return true;
-}
-
-bool PerfSerializer::DeserializeReadEvent(const PerfDataProto_ReadEvent& sample,
-                                          event_t* event) const {
-  struct read_event& read = event->read;
-  read.pid = sample.pid();
-  read.tid = sample.tid();
-  read.value = sample.value();
-  read.time_enabled = sample.time_enabled();
-  read.time_running = sample.time_running();
-  read.id = sample.id();
-
-  return true;
 }
 
 bool PerfSerializer::SerializeAuxEvent(const event_t& event,

--- a/src/quipper/perf_serializer.h
+++ b/src/quipper/perf_serializer.h
@@ -128,11 +128,6 @@ class PerfSerializer {
   bool DeserializeThrottleEvent(const PerfDataProto_ThrottleEvent& sample,
                                 event_t* event) const;
 
-  bool SerializeReadEvent(const event_t& event,
-                          PerfDataProto_ReadEvent* sample) const;
-  bool DeserializeReadEvent(const PerfDataProto_ReadEvent& sample,
-                            event_t* event) const;
-
   bool SerializeAuxEvent(const event_t& event,
                          PerfDataProto_AuxEvent* sample) const;
   bool DeserializeAuxEvent(const PerfDataProto_AuxEvent& sample,

--- a/src/quipper/perf_serializer_test.cc
+++ b/src/quipper/perf_serializer_test.cc
@@ -71,8 +71,6 @@ const uint64_t GetSampleTimestampFromEventProto(
     return event.lost_event().sample_info().sample_time_ns();
   } else if (event.has_throttle_event()) {
     return event.throttle_event().sample_info().sample_time_ns();
-  } else if (event.has_read_event()) {
-    return event.read_event().sample_info().sample_time_ns();
   } else if (event.has_aux_event()) {
     return event.aux_event().sample_info().sample_time_ns();
   } else if (event.has_itrace_start_event()) {

--- a/src/quipper/sample_info_reader.cc
+++ b/src/quipper/sample_info_reader.cc
@@ -698,7 +698,6 @@ bool SampleInfoReader::IsSupportedEventType(uint32_t type) {
     case PERF_RECORD_SAMPLE:
     case PERF_RECORD_MMAP:
     case PERF_RECORD_MMAP2:
-    case PERF_RECORD_READ:
     case PERF_RECORD_FORK:
     case PERF_RECORD_EXIT:
     case PERF_RECORD_COMM:
@@ -789,7 +788,6 @@ uint64_t SampleInfoReader::GetSampleFieldsForEventType(uint32_t event_type,
     case PERF_RECORD_THROTTLE:
     case PERF_RECORD_UNTHROTTLE:
     case PERF_RECORD_FORK:
-    case PERF_RECORD_READ:
     case PERF_RECORD_MMAP2:
     case PERF_RECORD_AUX:
     case PERF_RECORD_ITRACE_START:


### PR DESCRIPTION
PiperOrigin-RevId: 244373367

PERF_RECORD_READ is an old perf event, only partially supported, and not used.