### PR TITLE
Update copybara to internal head

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -77,6 +77,7 @@ cc_test(
     data = [
         "//src/testdata:multi-event-single-process.perf.data",
         "//src/testdata:perf-cros-kernel-3_18-mapping.pb_proto",
+        "//src/testdata:perf-non-exec-comm-events.pb_proto",
         "//src/testdata:perf-overlapping-kernel-mapping.pb_proto",
         "//src/testdata:single-event-multi-process.perf.data",
         "//src/testdata:single-event-multi-process-single-ip.pb_proto",

--- a/src/BUILD
+++ b/src/BUILD
@@ -77,6 +77,7 @@ cc_test(
     data = [
         "//src/testdata:multi-event-single-process.perf.data",
         "//src/testdata:perf-cros-kernel-3_18-mapping.pb_proto",
+        "//src/testdata:perf-include-comm-md5-prefix.pb_proto",
         "//src/testdata:perf-non-exec-comm-events.pb_proto",
         "//src/testdata:perf-overlapping-kernel-mapping.pb_proto",
         "//src/testdata:single-event-multi-process.perf.data",

--- a/src/perf_data_converter.cc
+++ b/src/perf_data_converter.cc
@@ -559,9 +559,9 @@ uint64 PerfDataConverter::AddOrGetLocation(
 void PerfDataConverter::Comm(const CommContext& comm) {
   Pid pid = comm.comm->pid();
   Tid tid = comm.comm->tid();
-  if (pid == tid) {
-    // pid==tid means an exec() happened, so clear everything from the
-    // existing pid.
+  if (comm.is_exec) {
+    // If is_exec set to true, it means an exec() happened, so clear everything
+    // from the existing pid.
     per_pid_[pid].clear();
   }
 

--- a/src/perf_data_converter_test.cc
+++ b/src/perf_data_converter_test.cc
@@ -399,6 +399,23 @@ TEST_F(PerfDataConverterTest, HandlesNonExecCommEvents) {
   EXPECT_EQ(2, profile2.sample_size());
 }
 
+TEST_F(PerfDataConverterTest, HandlesIncludingCommMd5Prefix) {
+  string path = GetResource(
+      "testdata"
+      "/perf-include-comm-md5-prefix.pb_proto");
+  string asciiPb;
+  GetContents(path, &asciiPb);
+  PerfDataProto perf_data_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(asciiPb, &perf_data_proto));
+  ProcessProfiles pps = PerfDataProtoToProfiles(&perf_data_proto);
+  EXPECT_EQ(1, pps.size());
+  const auto& profile = pps[0]->data;
+  EXPECT_EQ(1, profile.sample_size());
+  EXPECT_EQ(1, profile.mapping_size());
+  EXPECT_EQ("b8c090b480e340b7",
+            profile.string_table()[profile.mapping()[0].filename()]);
+}
+
 TEST_F(PerfDataConverterTest, PerfInfoSavedInComment) {
   string path = GetResource(
       "testdata"

--- a/src/perf_data_converter_test.cc
+++ b/src/perf_data_converter_test.cc
@@ -376,6 +376,29 @@ TEST_F(PerfDataConverterTest, HandlesCrOSKernel3_18Mapping) {
   EXPECT_EQ(0, profile.location(2).mapping_id());
 }
 
+TEST_F(PerfDataConverterTest, HandlesNonExecCommEvents) {
+  string path = GetResource(
+      "testdata"
+      "/perf-non-exec-comm-events.pb_proto");
+  string asciiPb;
+  GetContents(path, &asciiPb);
+  PerfDataProto perf_data_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(asciiPb, &perf_data_proto));
+  ProcessProfiles pps = PerfDataProtoToProfiles(&perf_data_proto);
+  EXPECT_EQ(2, pps.size());
+  const auto& profile1 = pps[0]->data;
+  const auto& profile2 = pps[1]->data;
+
+  EXPECT_EQ(2, profile1.mapping_size());
+  EXPECT_EQ(2, profile2.mapping_size());
+  EXPECT_EQ("/usr/lib/systemd/systemd-journald",
+            profile1.string_table(profile1.mapping(0).filename()));
+  EXPECT_EQ("/usr/bin/coreutils",
+            profile2.string_table(profile2.mapping(0).filename()));
+  EXPECT_EQ(2, profile1.sample_size());
+  EXPECT_EQ(2, profile2.sample_size());
+}
+
 TEST_F(PerfDataConverterTest, PerfInfoSavedInComment) {
   string path = GetResource(
       "testdata"

--- a/src/perf_data_handler.cc
+++ b/src/perf_data_handler.cc
@@ -339,8 +339,12 @@ void Normalizer::InvokeHandleSample(
       if (kernel_it != pid_to_executable_mmap_.end()) {
         build_id = kernel_it->second->build_id;
       }
-      fake.reset(new PerfDataHandler::Mapping(&comm_it->second->comm(),
-                                              build_id, 0, 1, 0, 0));
+      // The comm_md5_prefix is used for the filename_md5_prefix field in the
+      // fake mapping. This allows recovery of the process name (execname) by
+      // resolving its md5 prefix when the comm string is nil or empty.
+      fake.reset(
+          new PerfDataHandler::Mapping(&comm_it->second->comm(), build_id, 0, 1,
+                                       0, comm_it->second->comm_md5_prefix()));
       context.main_mapping = fake.get();
     } else if (pid == 0 && kernel_it != pid_to_executable_mmap_.end()) {
       // PID is 0 for the per-CPU idle tasks. Attribute these to the kernel.

--- a/src/perf_data_handler.h
+++ b/src/perf_data_handler.h
@@ -111,6 +111,8 @@ class PerfDataHandler {
   struct CommContext {
     // A comm event.
     const quipper::PerfDataProto::CommEvent* comm;
+    // Whether the comm event happens due to exec().
+    bool is_exec = false;
   };
 
   struct MMapContext {

--- a/src/quipper/test_perf_data.cc
+++ b/src/quipper/test_perf_data.cc
@@ -111,7 +111,8 @@ void ExamplePerfDataFileHeader::WriteTo(std::ostream* out) const {
   };
   // Copy over the features bits manually since the byte swapping is more
   // complicated.
-  for (size_t i = 0; i < sizeof(header_.adds_features) / sizeof(uint64_t);
+  // Add parentheses around sizeof(uint64_t) to quell -Wsizeof-array-div
+  for (size_t i = 0; i < sizeof(header_.adds_features) / (sizeof(uint64_t));
        ++i) {
     reinterpret_cast<uint64_t*>(local_header.adds_features)[i] = MaybeSwap64(
         reinterpret_cast<const uint64_t*>(header_.adds_features)[i]);

--- a/src/testdata/BUILD
+++ b/src/testdata/BUILD
@@ -7,6 +7,7 @@ exports_files(
         "LICENSE",
         "perf-overlapping-kernel-mapping.pb_proto",
         "perf-cros-kernel-3_18-mapping.pb_proto",
+        "perf-non-exec-comm-events.pb_proto",
         "single-event-single-process.perf.data",
         "single-event-multi-process.perf.data",
         "single-event-multi-process-single-ip.pb_proto",

--- a/src/testdata/BUILD
+++ b/src/testdata/BUILD
@@ -7,6 +7,7 @@ exports_files(
         "LICENSE",
         "perf-overlapping-kernel-mapping.pb_proto",
         "perf-cros-kernel-3_18-mapping.pb_proto",
+        "perf-include-comm-md5-prefix.pb_proto",
         "perf-non-exec-comm-events.pb_proto",
         "single-event-single-process.perf.data",
         "single-event-multi-process.perf.data",

--- a/src/testdata/perf-include-comm-md5-prefix.pb_proto
+++ b/src/testdata/perf-include-comm-md5-prefix.pb_proto
@@ -1,0 +1,99 @@
+file_attrs: {
+  attr: {
+    type    : 0x00000000
+    size    : 0x00000060
+    config  : 0x0000000000000000
+    sample_period   : 0x00000000000f4243
+    sample_type     : 0x0000000000000087
+    read_format     : 0x0000000000000000
+    disabled: true
+    inherit : true
+    pinned  : false
+    exclusive       : false
+    exclude_user    : false
+    exclude_kernel  : false
+    exclude_hv      : false
+    exclude_idle    : false
+    mmap    : true
+    comm    : true
+    freq    : false
+    inherit_stat    : false
+    enable_on_exec  : false
+    task    : true
+    watermark       : false
+    precise_ip      : 0x00000000
+    mmap_data       : false
+    sample_id_all   : true
+    exclude_host    : false
+    exclude_guest   : true
+    wakeup_events   : 0x00000000
+    bp_type : 0x00000000
+    bp_addr : 0x0000000000000000
+    bp_len  : 0x0000000000000000
+    branch_sample_type      : 0x0000000000000000
+    exclude_callchain_kernel: false
+    exclude_callchain_user  : false
+    mmap2   : false
+    comm_exec       : false
+    sample_regs_user: 0x0000000000000000
+    sample_stack_user       : 0x00000000
+    use_clockid     : false
+    context_switch  : false
+    write_backward  : false
+    namespaces      : false
+  }
+}
+events: {
+  header: {
+    type: 0x00000007
+    misc: 0x00000000
+  }
+  fork_event: {
+    pid : 0x0000003c
+    ppid: 0x00000002
+    tid : 0x0000003c
+    ptid: 0x00000002
+    fork_time_ns: 0x0000000000000000
+    sample_info: {
+      pid: 0x00000000
+      tid: 0x00000000
+      sample_time_ns: 0x0000000000000000
+      cpu: 0x00000000
+    }
+  }
+  timestamp   : 0x0000000000000000
+}
+events: {
+  header: {
+    type: 0x00000003
+    misc: 0x00000000
+  }
+  comm_event: {
+    pid : 0x0000003c
+    tid : 0x0000003c
+    comm_md5_prefix: 0xb8c090b480e340b7
+    sample_info: {
+      pid: 0x00000000
+      tid: 0x00000000
+      sample_time_ns: 0x0000000000000000
+      cpu: 0x00000000
+    }
+  }
+  timestamp   : 0x0000000000000000
+}
+events: {
+  header: {
+    type: 0x00000009
+    misc: 0x00000001
+  }
+  sample_event: {
+    ip    : 0x00000000005bd43c
+    pid   : 0x0000003c
+    tid   : 0x0000003c
+    sample_time_ns: 0x00003abf8b30e183
+    cpu   : 0x00000001
+  }
+  timestamp   : 0x00003abf8b30e183
+}
+timestamp_sec  : 0x000000005d8a55d9
+metadata_mask  : 0x0000000000113dfc

--- a/src/testdata/perf-non-exec-comm-events.pb_proto
+++ b/src/testdata/perf-non-exec-comm-events.pb_proto
@@ -1,0 +1,303 @@
+file_attrs: {
+  attr: {
+    type    : 0x00000000
+    size    : 0x00000060
+    config  : 0x0000000000000000
+    sample_period   : 0x00000000000f4243
+    sample_type     : 0x0000000000000087
+    read_format     : 0x0000000000000000
+    disabled: true
+    inherit : true
+    pinned  : false
+    exclusive       : false
+    exclude_user    : false
+    exclude_kernel  : false
+    exclude_hv      : false
+    exclude_idle    : false
+    mmap    : true
+    comm    : true
+    freq    : false
+    inherit_stat    : false
+    enable_on_exec  : false
+    task    : true
+    watermark       : false
+    precise_ip      : 0x00000000
+    mmap_data       : false
+    sample_id_all   : true
+    exclude_host    : false
+    exclude_guest   : true
+    wakeup_events   : 0x00000000
+    bp_type : 0x00000000
+    bp_addr : 0x0000000000000000
+    bp_len  : 0x0000000000000000
+    branch_sample_type      : 0x0000000000000000
+    exclude_callchain_kernel: false
+    exclude_callchain_user  : false
+    mmap2   : true
+    comm_exec       : true
+    sample_regs_user: 0x0000000000000000
+    sample_stack_user       : 0x00000000
+    use_clockid     : false
+    context_switch  : false
+    write_backward  : false
+    namespaces      : false
+  }
+}
+events: {
+  header: {
+    type: 0x00000007
+    misc: 0x00000000
+  }
+  fork_event: {
+    pid : 0x000001a9
+    ppid: 0x00000001
+    tid : 0x000001a9
+    ptid: 0x00000001
+    fork_time_ns: 0x0000000000000000
+    sample_info: {
+      pid: 0x00000000
+      tid: 0x00000000
+      sample_time_ns: 0x0000000000000000
+      cpu: 0x00000000
+    }
+  }
+  timestamp   : 0x0000000000000000
+}
+events: {
+  header: {
+    type: 0x00000003
+    misc: 0x00000000
+  }
+  comm_event: {
+    pid : 0x000001a9
+    tid : 0x000001a9
+    comm_md5_prefix: 0xec68e040f7321b3a
+    sample_info: {
+      pid: 0x000001a9
+      tid: 0x000001a9
+      sample_time_ns: 0x0000000000000000
+      cpu: 0x00000000
+    }
+  }
+  timestamp   : 0x0000000000000000
+}
+events: {
+  header: {
+    type: 0x0000000a
+    misc: 0x00000002
+  }
+  mmap_event: {
+    pid: 0x000001a9
+    tid: 0x000001a9
+    start      : 0x000000002a74e000
+    len: 0x000000000001e000
+    pgoff      : 0x0000000000000000
+    filename   : "/usr/lib/systemd/systemd-journald"
+    filename_md5_prefix: 0xd8bad91b06ade193
+    sample_info: {
+      pid: 0x000001a9
+      tid: 0x000001a9
+      sample_time_ns: 0x0000000000000000
+      cpu: 0x00000000
+    }
+  }
+  timestamp   : 0x0000000000000000
+}
+events: {
+  header: {
+    type: 0x0000000a
+    misc: 0x00000002
+  }
+  mmap_event: {
+    pid: 0x000001a9
+    tid: 0x000001a9
+    start      : 0x000000002ba56000
+    len: 0x000000000022a000
+    pgoff      : 0x0000000000000000
+    filename   : "/lib64/libpthread-2.27.so"
+    filename_md5_prefix: 0xe2ae10e6963f1c44
+    sample_info: {
+      pid: 0x000001a9
+      tid: 0x000001a9
+      sample_time_ns: 0x0003138567ef6fe1
+      cpu: 0x00000001
+    }
+  }
+  timestamp   : 0x0000000000000000
+}
+events: {
+  header: {
+    type: 0x00000009
+    misc: 0x00000001
+  }
+  sample_event: {
+    ip    : 0x000000002ba56001
+    pid   : 0x000001a9
+    tid   : 0x000001a9
+    sample_time_ns: 0x000313856b16ddba
+    cpu   : 0x00000001
+  }
+  timestamp   : 0x000313856b16ddba
+}
+events: {
+  header: {
+    type: 0x00000003
+    misc: 0x00000000
+  }
+  comm_event: {
+    pid : 0x000001a9
+    tid : 0x000001a9
+    comm_md5_prefix: 0xec68e040f7321b3a
+    sample_info: {
+      pid: 0x00000000
+      tid: 0x00000000
+      sample_time_ns: 0x000313856b1ce42d
+      cpu: 0x00000000
+    }
+  }
+  timestamp   : 0x000313856b1ce42d
+}
+events: {
+  header: {
+    type: 0x00000009
+    misc: 0x00000001
+  }
+  sample_event: {
+    ip    : 0x000000002ba56002
+    pid   : 0x000001a9
+    tid   : 0x000001a9
+    sample_time_ns: 0x000313856b22eadd
+    cpu   : 0x00000001
+  }
+  timestamp   : 0x000313856b22eadd
+}
+events: {
+  header: {
+    type: 0x00000007
+    misc: 0x00000000
+  }
+  fork_event: {
+    pid : 0x00005c25
+    ppid: 0x00005a7e
+    tid : 0x00005c25
+    ptid: 0x00005a7e
+    fork_time_ns: 0x0003138567e9d37c
+    sample_info: {
+      pid: 0x00005a7e
+      tid: 0x00005a7e
+      sample_time_ns: 0x0003138567e9cfdf
+      cpu: 0x00000001
+    }
+  }
+  timestamp   : 0x0003138567e9cfdf
+}
+events: {
+  header: {
+    type: 0x00000003
+    misc: 0x00002000
+  }
+  comm_event: {
+    pid : 0x00005c25
+    tid : 0x00005c25
+    comm_md5_prefix: 0xa43ff383fa074583
+    sample_info: {
+      pid: 0x00005c25
+      tid: 0x00005c25
+      sample_time_ns: 0x0003138567ee82ec
+      cpu: 0x00000001
+    }
+  }
+  timestamp   : 0x0003138567ee82ec
+}
+events: {
+  header: {
+    type: 0x0000000a
+    misc: 0x00000002
+  }
+  mmap_event: {
+    pid: 0x00005c25
+    tid: 0x00005c25
+    start      : 0x000000002a93e000
+    len: 0x0000000000118000
+    pgoff      : 0x0000000000000000
+    filename   : "/usr/bin/coreutils"
+    filename_md5_prefix: 0x41a84797c3255428
+    sample_info: {
+      pid: 0x00005c25
+      tid: 0x00005c25
+      sample_time_ns: 0x0003138567eef008
+      cpu: 0x00000001
+    }
+  }
+  timestamp   : 0x0003138567eef008
+}
+events: {
+  header: {
+    type: 0x0000000a
+    misc: 0x00000002
+  }
+  mmap_event: {
+    pid: 0x00005c25
+    tid: 0x00005c25
+    start      : 0x000000002ac56000
+    len: 0x000000000022a000
+    pgoff      : 0x0000000000000000
+    filename   : "/lib64/ld-2.27.so"
+    filename_md5_prefix: 0xe2ae10e6963f1c44
+    sample_info: {
+      pid: 0x00005c25
+      tid: 0x00005c25
+      sample_time_ns: 0x0003138567ef6fe1
+      cpu: 0x00000001
+    }
+  }
+  timestamp   : 0x0003138567ef6fe1
+}
+events: {
+  header: {
+    type: 0x00000009
+    misc: 0x00000001
+  }
+  sample_event: {
+    ip    : 0x000000002ac56001
+    pid   : 0x00005c25
+    tid   : 0x00005c25
+    sample_time_ns: 0x0003138567f2d69d
+    cpu   : 0x00000001
+  }
+  timestamp   : 0x0003138567f2d69d
+}
+events: {
+  header: {
+    type: 0x00000003
+    misc: 0x00000000
+  }
+  comm_event: {
+    pid : 0x00005c25
+    tid : 0x00005c25
+    comm_md5_prefix: 0xa43ff383fa074583
+    sample_info: {
+      pid: 0x00005c25
+      tid: 0x00005c25
+      sample_time_ns: 0x000313856804c70a
+      cpu: 0x00000001
+    }
+  }
+  timestamp   : 0x000313856804c70a
+}
+events: {
+  header: {
+    type: 0x00000009
+    misc: 0x00000001
+  }
+  sample_event: {
+    ip    : 0x000000002ac56002
+    pid   : 0x00005c25
+    tid   : 0x00005c25
+    sample_time_ns: 0x000313856804d574
+    cpu   : 0x00000001
+  }
+  timestamp   : 0x000313856804d574
+}
+timestamp_sec  : 0x000000005dab1f9d
+metadata_mask  : 0x0000000000113ffc


### PR DESCRIPTION
Motivation: quipper doesn't build with ToT clang without the -Werror, -Wsizeof-array-div fix, impacting chromium.