### PR TITLE
dep: update bazel dep rules-python

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,8 +18,8 @@ http_archive(
 # rules_python is a dependency for protobuf.
 http_archive(
     name = "rules_python",
-    urls = ["https://github.com/bazelbuild/rules_python/archive/master.tar.gz"],
-    strip_prefix = "rules_python-master",
+    urls = ["https://github.com/bazelbuild/rules_python/archive/main.tar.gz"],
+    strip_prefix = "rules_python-main",
 )
 
 # proto_library, cc_proto_library, and java_proto_library rules implicitly


### PR DESCRIPTION
The original master branch is removed from rules_python and `bazel build src:perf_to_profile` fails.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>