### PR TITLE
Fix rules_python dep. The upstream "master" branch was renamed "main"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,8 +18,8 @@ http_archive(
 # rules_python is a dependency for protobuf.
 http_archive(
     name = "rules_python",
-    urls = ["https://github.com/bazelbuild/rules_python/archive/master.tar.gz"],
-    strip_prefix = "rules_python-master",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz",
+    sha256 = "954aa89b491be4a083304a2cb838019c8b8c3720a7abb9c4cb81ac7a24230cea",
 )
 
 # proto_library, cc_proto_library, and java_proto_library rules implicitly


### PR DESCRIPTION
Build was currently failing with:

> ERROR: /usr/src/perf_data_converter/src/quipper/BUILD:25:14: //src/quipper:perf_data_proto depends on @com_google_protobuf//:protoc in repository @com_google_protobuf which failed to fetch. no such package '@rules_python//python': java.io.IOException: Error downloading [https://github.com/bazelbuild/rules_python/archive/master.tar.gz] to /root/.cache/bazel/_bazel_root/9a84914462919c338e94f245491500b7/external/rules_python/temp1309864731025550142/master.tar.gz: GET returned 404 Not Found


I could have fixed this by renaming the dep to `main.tar.gz`, but decided to follow the [recommended method](https://github.com/bazelbuild/rules_python#getting-started) of using a named release. 