### PR TITLE
Allow perf_data_converter to read file size larger than 4GB

### DIFF
--- a/src/perf_data_converter.cc
+++ b/src/perf_data_converter.cc
@@ -15,8 +15,6 @@
 #include <vector>
 
 #include "src/builder.h"
-#include "src/compat/int_compat.h"
-#include "src/compat/string_compat.h"
 #include "src/perf_data_handler.h"
 #include "src/quipper/perf_data.pb.h"
 #include "src/quipper/perf_parser.h"
@@ -741,7 +739,7 @@ ProcessProfiles PerfDataProtoToProfiles(
 }
 
 ProcessProfiles RawPerfDataToProfiles(
-    const void* raw, const int raw_size,
+    const void* raw, const uint64_t raw_size,
     const std::map<string, string>& build_ids, const uint32 sample_labels,
     const uint32 options, const std::map<Tid, string>& thread_types) {
   quipper::PerfReader reader;

--- a/src/perf_data_converter.h
+++ b/src/perf_data_converter.h
@@ -130,7 +130,7 @@ using ProcessProfiles = std::vector<std::unique_ptr<ProcessProfile>>;
 //
 // Returns a vector of process profiles, empty if any error occurs.
 extern ProcessProfiles RawPerfDataToProfiles(
-    const void* raw, int raw_size,
+    const void* raw, uint64_t raw_size,
     const std::map<std::string, std::string>& build_ids,
     uint32 sample_labels = kNoLabels, uint32 options = kGroupByPids,
     const std::map<uint32, std::string>& thread_types = {});


### PR DESCRIPTION
This changes the raw_size to uint64_t to allow quipper to take larger files. Note the underlying protobuf size is still capped at 2GB, which means this will not take arbitrary large files.

PiperOrigin-RevId: 458324805