### PR TITLE
Update to latest internal version pt. III

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,12 +47,12 @@ http_archive(
 # zlib is a dependency of protobuf.
 http_archive(
     name = "zlib",
-    sha256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
+    sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
     # This is the zlib BUILD file used in kythe:
     # https://github.com/kythe/kythe/blob/v0.0.30/third_party/zlib.BUILD
     build_file = "zlib.BUILD",
-    urls = ["https://www.zlib.net/zlib-1.2.12.tar.gz"],
-    strip_prefix = "zlib-1.2.12",
+    urls = ["https://www.zlib.net/zlib-1.2.13.tar.gz"],
+    strip_prefix = "zlib-1.2.13",
 )
 
 http_archive(

--- a/src/quipper/BUILD
+++ b/src/quipper/BUILD
@@ -82,7 +82,7 @@ cc_library(
         ":perf_parser_options_cc_proto",
         ":perf_stat_cc_proto",
         ":base",
-        "//net/proto2/public:proto2",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/src/quipper/compat/proto.h
+++ b/src/quipper/compat/proto.h
@@ -5,15 +5,15 @@
 #ifndef CHROMIUMOS_WIDE_PROFILING_COMPAT_PROTO_H_
 #define CHROMIUMOS_WIDE_PROFILING_COMPAT_PROTO_H_
 
-#include "net/proto2/io/public/zero_copy_stream_impl_lite.h"
-#include "net/proto2/public/arena.h"
-#include "net/proto2/public/message.h"
-#include "net/proto2/public/repeated_field.h"
-#include "net/proto2/public/text_format.h"
-#include "net/proto2/util/public/message_differencer.h"
 #include "perf_data.pb.h"
 #include "perf_parser_options.pb.h"
 #include "perf_stat.pb.h"
+#include "google/protobuf//arena.h"
+#include "google/protobuf//io/zero_copy_stream_impl_lite.h"
+#include "google/protobuf//message.h"
+#include "google/protobuf//repeated_field.h"
+#include "google/protobuf//text_format.h"
+#include "google/protobuf//util/message_differencer.h"
 
 namespace quipper {
 

--- a/src/quipper/conversion_utils.cc
+++ b/src/quipper/conversion_utils.cc
@@ -37,6 +37,8 @@ std::string ParseFormatOptions(std::string format, PerfParserOptions* options) {
     } else if (opt == "remap.discard") {
       options->do_remap = true;
       options->discard_unused_events = true;
+    } else if (opt == "no_combine") {
+      options->combine_mappings = false;
     } else {
       LOG(ERROR) << "Unknown option: " << opt;
       return "";

--- a/src/quipper/huge_page_deducer.cc
+++ b/src/quipper/huge_page_deducer.cc
@@ -67,6 +67,12 @@ bool IsHugePage(const MMapEvent& mmap) {
   return mmap.filename().length() > buildid_start + strlen(kBuildIdStr);
 }
 
+// Returns true if the two MMapEvents describe anonymous memory regions
+// that should be merged.
+bool IsMergeableAnon(const MMapEvent& a, const MMapEvent& b) {
+  return false;
+}
+
 // IsFileContiguous returns true if the mmap offset of |a| is immediately
 // followed by |b|, or if |a| is file backed and |b| is an anonymous mapping,
 // and therefore the file offset is meaningless for it. We don't combine
@@ -336,7 +342,7 @@ void DeduceHugePages(RepeatedPtrField<PerfEvent>* events) {
           const auto& mmap_range_last = huge_mmap_range_last->mmap_event();
           if (IsVmaContiguous(mmap_range_last, cur_mmap) &&
               (mmap_range_last.filename() == cur_mmap.filename() ||
-               (IsAnon(mmap_range_last) && IsAnon(cur_mmap))) &&
+               (IsMergeableAnon(mmap_range_last, cur_mmap))) &&
               (IsFileContiguous(mmap_range_last, cur_mmap) ||
                (mmap_range_last.pgoff() == 0 && cur_mmap.pgoff() == 0))) {
             // Ranges match exactly: //anon,//anon, or file,file; If they use

--- a/src/quipper/huge_page_deducer.cc
+++ b/src/quipper/huge_page_deducer.cc
@@ -335,7 +335,8 @@ void DeduceHugePages(RepeatedPtrField<PerfEvent>* events) {
         } else {
           const auto& mmap_range_last = huge_mmap_range_last->mmap_event();
           if (IsVmaContiguous(mmap_range_last, cur_mmap) &&
-              mmap_range_last.filename() == cur_mmap.filename() &&
+              (mmap_range_last.filename() == cur_mmap.filename() ||
+               (IsAnon(mmap_range_last) && IsAnon(cur_mmap))) &&
               (IsFileContiguous(mmap_range_last, cur_mmap) ||
                (mmap_range_last.pgoff() == 0 && cur_mmap.pgoff() == 0))) {
             // Ranges match exactly: //anon,//anon, or file,file; If they use


### PR DESCRIPTION
This is the last part to sync it up-to-date:

Add option to the format specifier of perf_convert to disable mapping combining.

Update zlib dependency to 1.2.13.

Internal changes.