### PR TITLE
Support reading perf sample regs user and perf sample stack user

### DIFF
--- a/src/quipper/kernel/perf_internals.h
+++ b/src/quipper/kernel/perf_internals.h
@@ -220,6 +220,11 @@ struct regs_dump {
 };
 #endif
 
+struct regs_dump {
+  u64 abi;
+  u64 regs[0];
+};
+
 struct stack_dump {
   u16 offset;
   u64 size;
@@ -307,8 +312,8 @@ struct perf_sample {
   void *raw_data;
   struct ip_callchain *callchain;
   struct branch_stack *branch_stack;
-  // struct regs_dump  user_regs;  // See struct regs_dump above.
-  struct stack_dump user_stack;
+  struct regs_dump    *user_regs;
+  struct stack_dump   user_stack;
   struct sample_read read;
   u64 physical_addr;
   u64 cgroup;
@@ -334,6 +339,7 @@ struct perf_sample {
         raw_data(nullptr),
         callchain(nullptr),
         branch_stack(nullptr),
+        user_regs(nullptr),
         user_stack({}),
         read({}),
         physical_addr(0),
@@ -343,6 +349,7 @@ struct perf_sample {
   ~perf_sample() {
     delete[] callchain;
     delete[] branch_stack;
+    delete[] user_regs;
     delete[] reinterpret_cast<char *>(raw_data);
   }
 };

--- a/src/quipper/kernel/perf_internals.h
+++ b/src/quipper/kernel/perf_internals.h
@@ -226,9 +226,12 @@ struct regs_dump {
 };
 
 struct stack_dump {
-  u16 offset;
-  u64 size;
-  char *data;
+  u64  size;
+  void *data;
+  u64  *dyn_size;
+
+  stack_dump() : size(0), data(nullptr), dyn_size(nullptr) {}
+  ~stack_dump() { delete[] reinterpret_cast<char *>(data); ; delete dyn_size; }
 };
 
 struct sample_read_value {

--- a/src/quipper/sample_info_reader.cc
+++ b/src/quipper/sample_info_reader.cc
@@ -264,6 +264,54 @@ bool ReadSampleRegsUser(DataReader* reader,
   return true;
 }
 
+// Reads user sample stack info from perf data. Corresponds to sample format
+// type PERF_SAMPLE_STACK_USER. Returns true when user sample stack data is
+// read completely. Otherwise, returns false.
+bool ReadSampleStackUser(DataReader* reader,
+                        const struct perf_event_attr& attr,
+                        struct perf_sample* sample) {
+  // Save the original read offset.
+  size_t reader_offset = reader->Tell();
+
+  uint64_t size = 0;
+  if (!reader->ReadUint64(&size)) {
+    LOG(ERROR) << "Failed to read the stack size.";
+    return false;
+  }
+  sample->user_stack.size = size;
+  if (sample->user_stack.size == 0) {
+    return true;
+  }
+
+  // Allocate space for and read the raw data bytes.
+  sample->user_stack.data = new uint8_t[sample->user_stack.size];
+  if (!reader->ReadData(sample->user_stack.size, sample->user_stack.data)) {
+      LOG(ERROR) << "Failed to read the stack data.";
+      return false;
+  }
+
+  sample->user_stack.dyn_size = new u64;
+  if (!reader->ReadUint64(sample->user_stack.dyn_size)) {
+    LOG(ERROR) << "Failed to read the dynamic size.";
+    return false;
+  }
+
+  if (*sample->user_stack.dyn_size > sample->user_stack.size) {
+    LOG(ERROR)
+        << "Dynamic size " << *sample->user_stack.dyn_size
+        << " cannot exceed the size of " << sample->user_stack.size;
+    return false;
+  }
+
+  // Determine the bytes that were read, and align to the next 64 bits.
+  reader_offset += Align<uint64_t>(sizeof(sample->user_stack.size) +
+                                   sample->user_stack.size +
+                                   sizeof(sample->user_stack.dyn_size));
+  if (!reader->SeekSet(reader_offset)) return false;
+
+  return true;
+}
+
 // Reads perf sample info data from |event| into |sample|.
 // |attr| is the event attribute struct, which contains info such as which
 // sample info fields are present.
@@ -448,8 +496,11 @@ bool ReadPerfSampleFromData(const event_t& event,
   //   char                  data[size];
   //   u64                   dyn_size; } && PERF_SAMPLE_STACK_USER
   if (sample_fields & PERF_SAMPLE_STACK_USER) {
-    LOG(ERROR) << "PERF_SAMPLE_STACK_USER is not yet supported.";
-    return false;
+    //if (!ReadSampleStackUser(&reader, sample)) {
+    if (!ReadSampleStackUser(&reader, attr, sample)) {
+      LOG(ERROR) << "Couldn't read PERF_SAMPLE_STACK_USER";
+      return false;
+    }
   }
 
   /*


### PR DESCRIPTION
The README states that PRs aren't used but doesn't state where I should send the code so putting it here first. Happy to send it elsewhere.

Motivation: `--call-graph dwarf` option creates `PERF_SAMPLE_REGS_USER` and `PERF_SAMPLE_STACK_USER` perf sample types. By supporting reading these sample types, `perf_data_converter` will be able to support `--call-graph dwarf`.

The existing tests pass and `perf_to_profile` is able to process `perf.data` but throws these warnings:

```
[WARNING:src/quipper/huge_page_deducer.cc:29] //anon should have offset=0 for mmap pid: 1903316 tid: 1903316 start: 94459214897152 len: 61440 pgoff: 94459214897152 filename: "//anon" filename_md5_prefix: 11476964321930150911 sample_info { pid: 1903316 tid: 1903316 sample
_time_ns: 3548743345884951 } maj: 0 min: 0 ino: 0 ino_generation: 0 prot: 3 flags: 2 root_path: "/" root_path_md5_prefix: 7378810950367401542                                                                                                                                  
[WARNING:src/quipper/huge_page_deducer.cc:29] //anon should have offset=0 for mmap pid: 1903316 tid: 1903316 start: 94459214897152 len: 61440 pgoff: 94459214897152 filename: "//anon" filename_md5_prefix: 11476964321930150911 sample_info { pid: 1903316 tid: 1903316 sample
_time_ns: 3548743345884951 } maj: 0 min: 0 ino: 0 ino_generation: 0 prot: 3 flags: 2 root_path: "/" root_path_md5_prefix: 7378810950367401542                                                                                                                                  
[WARNING:src/quipper/huge_page_deducer.cc:29] //anon should have offset=0 for mmap pid: 1903316 tid: 1903316 start: 140001533415424 len: 8192 pgoff: 140001533415424 filename: "//anon" filename_md5_prefix: 11476964321930150911 sample_info { pid: 1903316 tid: 1903316 sampl
e_time_ns: 3548743345997041 } maj: 0 min: 0 ino: 0 ino_generation: 0 prot: 3 flags: 2 root_path: "/" root_path_md5_prefix: 7378810950367401542                                                                                                                                 
[WARNING:src/quipper/huge_page_deducer.cc:29] //anon should have offset=0 for mmap pid: 1903316 tid: 1903316 start: 140001533415424 len: 8192 pgoff: 140001533415424 filename: "//anon" filename_md5_prefix: 11476964321930150911 sample_info { pid: 1903316 tid: 1903316 sampl
e_time_ns: 3548743345997041 } maj: 0 min: 0 ino: 0 ino_generation: 0 prot: 3 flags: 2 root_path: "/" root_path_md5_prefix: 7378810950367401542
[WARNING:src/quipper/huge_page_deducer.cc:29] //anon should have offset=0 for mmap pid: 1903316 tid: 1903316 start: 140001533415424 len: 8192 pgoff: 140001533415424 filename: "//anon" filename_md5_prefix: 11476964321930150911 sample_info { pid: 1903316 tid: 1903316 sampl
e_time_ns: 3548743345997041 } maj: 0 min: 0 ino: 0 ino_generation: 0 prot: 3 flags: 2 root_path: "/" root_path_md5_prefix: 7378810950367401542
```

Haven't yet had the chance to look at what these are exactly at the moment.