### PR TITLE
Only include logging.h in cc files.

### DIFF
--- a/src/intervalmap.h
+++ b/src/intervalmap.h
@@ -13,8 +13,6 @@
 #include <map>
 #include <sstream>
 
-#include "src/quipper/base/logging.h"
-
 namespace perftools {
 
 template <class V>

--- a/src/perf_to_profile_lib.h
+++ b/src/perf_to_profile_lib.h
@@ -11,7 +11,6 @@
 #include <unistd.h>
 #include <fstream>
 
-#include "src/quipper/base/logging.h"
 #include "src/perf_data_converter.h"
 #include "src/quipper/perf_data.pb.h"
 

--- a/src/quipper/base/logging.h
+++ b/src/quipper/base/logging.h
@@ -8,7 +8,7 @@
 #include <errno.h>   // for errno
 #include <string.h>  // for strerror
 
-#include <iostream>  
+#include <iostream>
 #include <sstream>
 #include <string>
 
@@ -112,11 +112,17 @@ class VLog : public LogBase {
 
 }  // namespace logging
 
-// These macros are for LOG() and related logging commands.
+// These macros are for LOG() and related logging commands. Define them if not
+// defined already.
+#ifndef LOG
 #define LOG(level) logging::Log(level, #level, __FILE__, __LINE__)
 #define PLOG(level) logging::PLog(level, #level, __FILE__, __LINE__)
 #define VLOG(level) logging::VLog(level, __FILE__, __LINE__)
+#endif  // LOG
 
+// These macros are for LOG() and related logging commands. Define them if not
+// defined already.
+#ifndef CHECK
 // Some macros from libbase that we use.
 #define CHECK(x) \
   if (!(x)) LOG(FATAL) << #x
@@ -140,5 +146,6 @@ class VLog : public LogBase {
 #define DCHECK_LE(x, y) CHECK_LE(x, y)
 #define DCHECK_NE(x, y) CHECK_NE(x, y)
 #define DCHECK_EQ(x, y) CHECK_EQ(x, y)
+#endif  // CHECK
 
 #endif  // CHROMIUMOS_WIDE_PROFILING_MYBASE_BASE_LOGGING_H_

--- a/src/quipper/binary_data_utils.cc
+++ b/src/quipper/binary_data_utils.cc
@@ -14,6 +14,8 @@
 #include <cstring>
 #include <fstream>  
 
+#include "base/logging.h"
+
 namespace {
 
 // Number of hex digits in a byte.
@@ -81,5 +83,34 @@ bool HexStringToRawData(const std::string& str, u8* array, size_t length) {
   }
   return true;
 }
+
+// Swaps the byte order of 16-bit, 32-bit, and 64-bit unsigned integers.
+template <class T>
+void ByteSwap(T* input) {
+  switch (sizeof(T)) {
+    case sizeof(uint8_t):
+      LOG(WARNING) << "Attempting to byte swap on a single byte.";
+      break;
+    case sizeof(uint16_t):
+      *input = bswap_16(*input);
+      break;
+    case sizeof(uint32_t):
+      *input = bswap_32(*input);
+      break;
+    case sizeof(uint64_t):
+      *input = bswap_64(*input);
+      break;
+    default:
+      LOG(FATAL) << "Invalid size for byte swap: " << sizeof(T) << " bytes";
+      break;
+  }
+}
+
+template void ByteSwap<uint16_t>(uint16_t*);
+template void ByteSwap<uint32_t>(uint32_t*);
+template void ByteSwap<uint64_t>(uint64_t*);
+template void ByteSwap<int32_t>(int32_t*);
+template void ByteSwap<unsigned long long>(unsigned long long*);
+
 
 }  // namespace quipper

--- a/src/quipper/binary_data_utils.h
+++ b/src/quipper/binary_data_utils.h
@@ -13,32 +13,13 @@
 #include <type_traits>
 #include <vector>
 
-#include "base/logging.h"
 #include "kernel/perf_internals.h"
 
 namespace quipper {
 
 // Swaps the byte order of 16-bit, 32-bit, and 64-bit unsigned integers.
 template <class T>
-void ByteSwap(T* input) {
-  switch (sizeof(T)) {
-    case sizeof(uint8_t):
-      LOG(WARNING) << "Attempting to byte swap on a single byte.";
-      break;
-    case sizeof(uint16_t):
-      *input = bswap_16(*input);
-      break;
-    case sizeof(uint32_t):
-      *input = bswap_32(*input);
-      break;
-    case sizeof(uint64_t):
-      *input = bswap_64(*input);
-      break;
-    default:
-      LOG(FATAL) << "Invalid size for byte swap: " << sizeof(T) << " bytes";
-      break;
-  }
-}
+  void ByteSwap(T* input);
 
 // Swaps byte order of |value| if the |swap| flag is set. This function is
 // trivial but it avoids filling code with "if (swap) { ... } " statements.

--- a/src/quipper/buffer_reader.cc
+++ b/src/quipper/buffer_reader.cc
@@ -8,6 +8,8 @@
 
 #include <cstdint>
 
+#include "base/logging.h"
+
 namespace quipper {
 
 bool BufferReader::SeekSet(size_t offset) {

--- a/src/quipper/file_reader.cc
+++ b/src/quipper/file_reader.cc
@@ -9,6 +9,8 @@
 #include <cstdint>
 #include <memory>
 
+#include "base/logging.h"
+
 namespace quipper {
 
 FileReader::FileReader(const std::string& filename) {

--- a/src/quipper/file_utils.h
+++ b/src/quipper/file_utils.h
@@ -5,9 +5,8 @@
 #ifndef CHROMIUMOS_WIDE_PROFILING_FILE_UTILS_H_
 #define CHROMIUMOS_WIDE_PROFILING_FILE_UTILS_H_
 
+#include <string>
 #include <vector>
-
-#include "base/logging.h"
 
 namespace quipper {
 


### PR DESCRIPTION
google/autofdo is moving from glog to abseil. This PR allows us to link cleanly with quipper without annoying macro-redefinition warnings. 
