### PR TITLE
Update to latest internal version 

### DIFF
--- a/src/quipper/perf_reader.cc
+++ b/src/quipper/perf_reader.cc
@@ -10,6 +10,7 @@
 #include <sys/time.h>
 
 #include <algorithm>
+#include <limits>
 #include <vector>
 
 #include "base/logging.h"
@@ -1511,6 +1512,10 @@ bool PerfReader::ReadEventDescMetadata(DataReader* data) {
   u32 nr_events;
   if (!data->ReadUint32(&nr_events)) {
     LOG(ERROR) << "Error reading event_desc nr_events.";
+    return false;
+  }
+  if (nr_events > std::numeric_limits<int>::max()) {
+    LOG(ERROR) << "Parsed nr_events exceeds the max representable int value.";
     return false;
   }
 

--- a/src/quipper/string_utils.cc
+++ b/src/quipper/string_utils.cc
@@ -31,6 +31,8 @@ std::string RootPath(const std::string& filename) {
   // custom root paths for them..
   if (filename.rfind("[anon:", 0) == 0) return "[anon:";
   if (filename.rfind("/memfd:", 0) == 0) return "/memfd:";
+  // For temporary files and directory, capture only the top level directory.
+  if (filename.rfind("/tmp/", 0) == 0) return "/tmp";
   if (filename[0] != '/') return "";
   std::string root_path = "";
   size_t pos = 1;

--- a/src/quipper/string_utils_test.cc
+++ b/src/quipper/string_utils_test.cc
@@ -20,6 +20,9 @@ TEST(StringUtilsTest, RootPathExtraction) {
   EXPECT_EQ(RootPath("[vdso]"), "");
   EXPECT_EQ(RootPath("[anon:Mem0x20000]"), "[anon:");
   EXPECT_EQ(RootPath("/memfd:temp_file (deleted)"), "/memfd:");
+  EXPECT_EQ(RootPath("/tmp/aa)"), "/tmp");
+  EXPECT_EQ(RootPath("/tmp/aa/bb)"), "/tmp");
+  EXPECT_EQ(RootPath("/tmpdir/aa/bb)"), "/tmpdir/aa");
 }
 
 }  // namespace quipper


### PR DESCRIPTION
* Check that the parsed number of events doesn't exceed the maximum representable
* Set root path to "/tmp" for temporary files.