### PR TITLE
.bazelrc: update -W, read user.bazlrc. Fix missing include, uninitiali…

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,10 +1,12 @@
 # Require c++17 for c++ files.
 build --cxxopt='-std=c++17'
-# Disable warnings building zlib.
-build --copt='-Wno-deprecated-non-prototype'
+build --copt='-Wno-sign-compare'
 
 # Disable Bzlmod, a new external dependency management system on by default
 # since Bazel 7.0.0. This breaks compilation of protobuf by pulling in an older
 # version than what is specified in WORKSPACE.
 # TODO(b/319726507): Remove this when we have a better fix or move to Bzlmod.
 build --noenable_bzlmod
+
+# Load user-specific configuration, if any.
+try-import %workspace%/user.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.d
 *.o
 *.log
+*~
+user.bazelrc
 
 quipper
 perf_converter

--- a/src/perf_data_converter_test.cc
+++ b/src/perf_data_converter_test.cc
@@ -67,7 +67,7 @@ MapCounts GetMapCounts(const ProcessProfiles& pps) {
         key_stream << profile.string_table(main.filename()) << ":"
                    << profile.string_table(main.build_id());
         if (locations[id]->mapping_id() != 0) {
-          const Mapping* dso;
+          const Mapping* dso = nullptr;
           uint64_t addr = locations[id]->address();
           CHECK(mappings.Lookup(addr, &dso));
           key_stream << "+" << profile.string_table(dso->filename()) << ":"

--- a/src/quipper/string_utils.h
+++ b/src/quipper/string_utils.h
@@ -5,6 +5,7 @@
 #ifndef CHROMIUMOS_WIDE_PROFILING_STRING_UTILS_H_
 #define CHROMIUMOS_WIDE_PROFILING_STRING_UTILS_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
…zed variable.

 * .bazelrc: The warning silenced referencs zlib that had this warning fixed in 1.3, which is the version currently used by perf_data_converter.
 * Instead, add the warning about signed comparing as Google code prefers signed variables for safety, thus unsigned/signed comparison should not warn.
 * Add an optionally loaded user.bazelrc as that is very useful to add local options without having to edit the main .bazelrc Common practice and documented in bazel https://github.com/bazelbuild/bazel/blob/master/.bazelrc#L61 https://bazel.build/configure/best-practices#bazelrc-file
 * .gitignore: add user.bazelrc and *~ (common emacs backup file name)
 * string_utils.h: Fix a missing include <cstdint> for the use of uint32_t
 * perf_data_converter_test.cc: initialize an uninitialized variable the compiler can't figure out if it is set later and warns about.