### PR TITLE
Make reproducible: Use fixed version and add sha256 hashes to WORKSPACE rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,6 +12,7 @@ http_archive(
 # TODO(b/210576094): Unpin dependency after fixing compatibility.
 http_archive(
      name = "com_google_googletest",
+     sha256 = "353571c2440176ded91c2de6d6cd88ddd41401d14692ec1f99e35d013feda55a",
      urls = ["https://github.com/google/googletest/archive/release-1.11.0.zip"],
      strip_prefix = "googletest-release-1.11.0",
 )
@@ -62,8 +63,9 @@ http_archive(
 
 http_archive(
     name   = "com_github_gflags_gflags",
-    urls = ["https://github.com/gflags/gflags/archive/master.zip"],
-    strip_prefix = "gflags-master",
+    sha256 = "d68d13fd62957314d67b239bea6d6957b11e58ce53fa0e8d6f5ecb212ec7f9e0",
+    urls = ["https://github.com/gflags/gflags/archive/a738fdf9338412f83ab3f26f31ac11ed3f3ec4bd.tar.gz"],
+    strip_prefix = "gflags-a738fdf9338412f83ab3f26f31ac11ed3f3ec4bd",
 )
 
 http_archive(


### PR DESCRIPTION
Googletest was left without sha256, and gflags was downloading a moving target.