### PR TITLE
Check for malformed list when parsing hybrid topology metadata CPU list.

### DIFF
--- a/src/quipper/string_utils.cc
+++ b/src/quipper/string_utils.cc
@@ -69,7 +69,7 @@ bool ParseCPUNumbers(const std::string& cpus, std::vector<uint32_t>& result) {
     std::vector<std::string> range_tokens;
     SplitString(token, '-', &range_tokens);
 
-    if (range_tokens.size() > 2) {
+    if (range_tokens.empty() || range_tokens.size() > 2) {
       return false;
     }
 

--- a/src/quipper/string_utils_test.cc
+++ b/src/quipper/string_utils_test.cc
@@ -46,6 +46,7 @@ TEST(StringUtilsTest, ParseCPUNumbers) {
   EXPECT_THAT(result, ElementsAre(0, 1, 2, 3, 5, 6, 7));
   result.clear();
   EXPECT_FALSE(ParseCPUNumbers("", result));
+  EXPECT_FALSE(ParseCPUNumbers(",", result));
   EXPECT_FALSE(ParseCPUNumbers("a", result));
   EXPECT_FALSE(ParseCPUNumbers("0,1-2-3", result));
 }


### PR DESCRIPTION
PiperOrigin-RevId: 643155348