### PR TITLE
Don't symbolize addresses from guest VMs.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -75,6 +75,7 @@ cc_test(
     srcs = ["perf_data_converter_test.cc"],
     data = [
         "//src/testdata:multi-event-single-process.perf.data",
+        "//src/testdata:perf-address-context.textproto",
         "//src/testdata:perf-buildid-mmap-events.textproto",
         "//src/testdata:perf-buildid-stats.textproto",
         "//src/testdata:perf-callchain-non-pebs.textproto",

--- a/src/BUILD
+++ b/src/BUILD
@@ -17,6 +17,7 @@ cc_library(
     ],
     deps = [
         ":intervalmap",
+        "//src/quipper:address_context",
         "//src/quipper:arm_spe_decoder",
         "//src/quipper:binary_data_utils",
         "//src/quipper:dso",
@@ -35,6 +36,7 @@ cc_library(
         ":perf_data_handler",
         ":builder",
         ":profile_cc_proto",
+        "//src/quipper:address_context",
         "//src/quipper:kernel",
         "//src/quipper:perf_data_cc_proto",
         "//src/quipper:perf_parser",

--- a/src/quipper/BUILD
+++ b/src/quipper/BUILD
@@ -230,6 +230,17 @@ cc_library(
 )
 
 cc_library(
+    name = "address_context",
+    srcs = ["address_context.cc"],
+    hdrs = ["address_context.h"],
+    visibility = ["//src:__subpackages__"],
+    deps = [
+        ":kernel",
+        ":perf_data_cc_proto",
+    ],
+)
+
+cc_library(
     name = "address_mapper",
     srcs = ["address_mapper.cc"],
     hdrs = ["address_mapper.h"],

--- a/src/quipper/address_context.cc
+++ b/src/quipper/address_context.cc
@@ -1,0 +1,47 @@
+#include "address_context.h"
+
+#include "kernel/perf_event.h"
+#include "src/quipper/perf_data.pb.h"
+
+namespace quipper {
+
+AddressContext ContextFromHeader(const PerfDataProto::EventHeader& header) {
+  if (header.has_misc()) {
+    switch (header.misc() & PERF_RECORD_MISC_CPUMODE_MASK) {
+      case PERF_RECORD_MISC_KERNEL:
+        return AddressContext::kHostKernel;
+      case PERF_RECORD_MISC_USER:
+        return AddressContext::kHostUser;
+      case PERF_RECORD_MISC_GUEST_KERNEL:
+        return AddressContext::kGuestKernel;
+      case PERF_RECORD_MISC_GUEST_USER:
+        return AddressContext::kGuestUser;
+      case PERF_RECORD_MISC_HYPERVISOR:
+        return AddressContext::kHypervisor;
+    }
+  }
+  return AddressContext::kUnknown;
+}
+
+AddressContext ContextFromCallchain(enum perf_callchain_context context) {
+  // These PERF_CONTEXT_* values are magic constants used as entries in a
+  // perf_callchain to demarcate contexts within that stack. Most values in
+  // the stack will be valid program counters, and as such this will return
+  // kUnknown for them.
+  switch (context) {
+    case PERF_CONTEXT_HV:
+      return AddressContext::kHypervisor;
+    case PERF_CONTEXT_KERNEL:
+      return AddressContext::kHostKernel;
+    case PERF_CONTEXT_USER:
+      return AddressContext::kHostUser;
+    case PERF_CONTEXT_GUEST_KERNEL:
+      return AddressContext::kGuestKernel;
+    case PERF_CONTEXT_GUEST_USER:
+      return AddressContext::kGuestUser;
+    default:
+      return AddressContext::kUnknown;
+  }
+}
+
+}  // namespace quipper

--- a/src/quipper/address_context.h
+++ b/src/quipper/address_context.h
@@ -1,0 +1,24 @@
+#ifndef PERF_DATA_CONVERTER_SRC_QUIPPER_ADDRESS_CONTEXT_H_
+#define PERF_DATA_CONVERTER_SRC_QUIPPER_ADDRESS_CONTEXT_H_
+
+#include "kernel/perf_event.h"
+#include "src/quipper/perf_data.pb.h"
+
+namespace quipper {
+
+enum class AddressContext {
+  kUnknown,
+  kHostKernel,
+  kHostUser,
+  kGuestKernel,
+  kGuestUser,
+  kHypervisor
+};
+
+AddressContext ContextFromHeader(
+    const quipper::PerfDataProto::EventHeader& header);
+AddressContext ContextFromCallchain(enum perf_callchain_context context);
+
+}  // namespace quipper
+
+#endif  // PERF_DATA_CONVERTER_SRC_QUIPPER_ADDRESS_CONTEXT_H_

--- a/src/quipper/compat/proto.h
+++ b/src/quipper/compat/proto.h
@@ -5,7 +5,7 @@
 #ifndef CHROMIUMOS_WIDE_PROFILING_COMPAT_PROTO_H_
 #define CHROMIUMOS_WIDE_PROFILING_COMPAT_PROTO_H_
 
-#include "perf_data.pb.h"
+#include "src/quipper/perf_data.pb.h"
 #include "perf_parser_options.pb.h"
 #include "perf_stat.pb.h"
 #include "google/protobuf//arena.h"

--- a/src/quipper/perf_parser.cc
+++ b/src/quipper/perf_parser.cc
@@ -654,8 +654,8 @@ bool PerfParser::MapIPAndPidAndGetNameAndOffset(
     // address is guaranteed to be larger than the mapped quipper space. When
     // options_.do_remap is false, the kernel addresses of x86 and ARM have
     // the high 16 bit set and PowerPC has a reserved space from
-    // 0x1000000000000000 to 0xBFFFFFFFFFFFFFFF. Thus, setting highest byte of
-    // the unmapped address, which starts with 0x8, should not collide with
+    // 0x1000000000000000 to 0xBFFFFFFFFFFFFFFF. Thus, setting highest 4 bits
+    // of the unmapped address, which starts with 0x8, should not collide with
     // any existing addresses or mapped quipper addresses.
     mapped_addr = (ip & ~(0xfULL << 60)) | 0x8ULL << 60;
   }

--- a/src/testdata/perf-address-context.textproto
+++ b/src/testdata/perf-address-context.textproto
@@ -1,0 +1,222 @@
+# proto-file: src/quipper/perf_data.proto
+# proto-message: quipper.PerfDataProto
+file_attrs {
+  attr {
+    type: 4
+    size: 96
+    config: 60
+    sample_period: 100000007
+    sample_type: 2162855
+    read_format: 20
+    disabled: true
+    inherit: false
+    pinned: false
+    exclusive: false
+    exclude_user: false
+    exclude_kernel: false
+    exclude_hv: false
+    exclude_idle: false
+    mmap: false
+    comm: false
+    freq: false
+    inherit_stat: false
+    enable_on_exec: false
+    task: false
+    watermark: false
+    precise_ip: 0
+    mmap_data: false
+    sample_id_all: true
+    exclude_host: false
+    exclude_guest: false
+    wakeup_events: 0
+    bp_type: 0
+    bp_addr: 0
+    bp_len: 0
+    branch_sample_type: 0
+    exclude_callchain_kernel: false
+    exclude_callchain_user: false
+    mmap2: false
+    comm_exec: false
+    sample_regs_user: 0
+    sample_stack_user: 0
+    use_clockid: false
+    context_switch: false
+    write_backward: false
+    namespaces: false
+    cgroup: false
+    ksymbol: false
+  }
+  ids: 11
+  ids: 12
+  ids: 14
+  ids: 15
+}
+event_types: {
+  id: 0
+  name: "some_type"
+}
+events {
+  header {
+    type: 1
+    misc: 1
+    size: 96
+  }
+  mmap_event {
+    pid: 4294967295
+    tid: 0
+    start: 0xffffffff93600000
+    len: 0x215bf80
+    pgoff: 0xffffffff93600000
+    filename: "[kernel.kallsyms]_text"
+  }
+}
+events {
+  header {
+    type: 1
+    misc: 1
+    size: 80
+  }
+  mmap_event {
+    pid: 100
+    tid: 100
+    start: 0x55d9eda00000
+    len: 0x100000
+    pgoff: 0x100000
+    filename: "/bin/ls"
+  }
+}
+events {
+  header {
+    type: 1
+    misc: 1
+    size: 80
+  }
+  mmap_event {
+    pid: 200
+    tid: 200
+    start: 0x561c5e200000
+    len: 0x100000
+    pgoff: 0x100000
+    filename: "/bin/vi"
+  }
+}
+events {
+  header {
+    type: 1
+    misc: 1
+    size: 96
+  }
+  mmap_event {
+    pid: 4294967295
+    tid: 0
+    start: 0xffffffffabe00000
+    len: 0x2222000
+    pgoff: 0xffffffffabe00000
+    filename: "[kernel.kallsyms]_bad"
+  }
+}
+events {
+  header {
+    type: 1
+    misc: 1
+    size: 80
+  }
+  mmap_event {
+    pid: 500
+    tid: 500
+    start: 0x564b73500000
+    len: 0x100000
+    pgoff: 0x100000
+    filename: "/bad/no"
+  }
+}
+events {
+  header {
+    type: 9
+    misc: 1
+    size: 112
+  }
+  sample_event {
+    ip: 0xffffffff93a9a8fd
+    pid: 100
+    tid: 100
+    sample_time_ns: 111111111
+    id: 11
+    cpu: 3
+    callchain: 0xffffffffffffff80
+    callchain: 0xffffffff93a9a8fd
+    callchain: 0xffffffff936144cf
+    callchain: 0xfffffffffffffe00
+    callchain: 0x55d9eda09999
+    callchain: 0x55d9eda0aaaa
+    cgroup: 1893
+  }
+  timestamp: 111111111
+}
+events {
+  header {
+    type: 9
+    misc: 2
+    size: 88
+  }
+  sample_event {
+    ip: 0x561c5e20bbbb
+    pid: 200
+    tid: 200
+    sample_time_ns: 222222222
+    id: 12
+    cpu: 4
+    callchain: 0xfffffffffffffe00
+    callchain: 0x561c5e20bbbb
+    callchain: 0x561c5e20cccc
+  }
+  timestamp: 222222222
+}
+events {
+  header {
+    type: 9
+    misc: 4
+    size: 80
+  }
+  sample_event {
+    ip: 0xffffffffabe012c5
+    pid: 400
+    tid: 400
+    sample_time_ns: 444444444
+    id: 14
+    cpu: 5
+    callchain: 0xffffffffffffff80
+    callchain: 0xfffffffffffffe00
+    cgroup: 181553
+  }
+  timestamp: 444444444
+}
+events {
+  header {
+    type: 9
+    misc: 5
+    size: 80
+  }
+  sample_event {
+    ip: 0x564b735f2035
+    pid: 500
+    tid: 500
+    sample_time_ns: 555555555
+    id: 15
+    cpu: 0
+    callchain: 0xffffffffffffff80
+    callchain: 0xfffffffffffffe00
+    cgroup: 1234
+  }
+  timestamp: 555555555
+}
+timestamp_sec: 0
+stats {
+  num_sample_events: 4
+  num_mmap_events: 0
+  num_fork_events: 0
+  num_exit_events: 0
+  num_sample_events_mapped: 2
+  did_remap: false
+}
+metadata_mask: 0

--- a/src/testdata/single-event-multi-process-single-ip.textproto
+++ b/src/testdata/single-event-multi-process-single-ip.textproto
@@ -112,7 +112,7 @@ events: {
 events: {
   header: {
     type: 0x00000009
-    misc: 0x00000002
+    misc: 0x00000001
   }
   sample_event: {
     ip: 0x00000000000b0a81
@@ -140,7 +140,7 @@ events: {
 events: {
   header: {
     type: 0x00000009
-    misc: 0x00000002
+    misc: 0x00000001
   }
   sample_event: {
     ip: 0x00000000000b0a81
@@ -154,7 +154,7 @@ events: {
 events: {
   header: {
     type: 0x00000009
-    misc: 0x00000002
+    misc: 0x00000001
   }
   sample_event: {
     ip: 0x00000000000b0a81
@@ -168,7 +168,7 @@ events: {
 events: {
   header: {
     type: 0x00000009
-    misc: 0x00000002
+    misc: 0x00000001
   }
   sample_event: {
     ip: 0x00000000000b0a81


### PR DESCRIPTION
Attempts to symbolize guest addresses in the host wind up creating extremely confusing samples. The host should avoid assuming that it can make any sense of these addresses; specifically, it should not try to assign a mapping to them.