### PR TITLE
-Add -g option to save sample indices following Go's PGO requirements

### DIFF
--- a/src/perf_data_converter.h
+++ b/src/perf_data_converter.h
@@ -115,6 +115,10 @@ enum ConversionOptions {
   // Whether to add sampled data addresses as leaf frames for converted
   // profiles.
   kAddDataAddressFrames = 8,
+  // Whether to save sample indices following Go's PGO requirements,
+  // with at least one of the indices having type/unit of samples/count
+  // or cpu/nanoseconds. https://go.dev/doc/pgo#alternative-sources
+  kFollowGoPgoRequirements = 16,
 };
 
 struct ProcessProfile {

--- a/src/perf_to_profile.cc
+++ b/src/perf_to_profile.cc
@@ -14,8 +14,9 @@ int main(int argc, char** argv) {
   std::string input, output;
   bool overwriteOutput = false;
   bool allowUnalignedJitMappings = false;
+  bool followGoPgoRequirements = false;
   if (!ParseArguments(argc, const_cast<const char**>(argv), &input, &output,
-                      &overwriteOutput, &allowUnalignedJitMappings)) {
+                      &overwriteOutput, &allowUnalignedJitMappings, &followGoPgoRequirements)) {
     PrintUsage();
     return EXIT_FAILURE;
   }
@@ -23,6 +24,9 @@ int main(int argc, char** argv) {
   uint32_t options = perftools::kNoOptions;
   if (allowUnalignedJitMappings) {
     options |= perftools::ConversionOptions::kAllowUnalignedJitMappings;
+  }
+  if (followGoPgoRequirements) {
+    options |= perftools::ConversionOptions::kFollowGoPgoRequirements;
   }
   std::string data = ReadFileToString(input);
   const auto profiles = StringToProfiles(data, perftools::kNoLabels, options);

--- a/src/perf_to_profile_lib.cc
+++ b/src/perf_to_profile_lib.cc
@@ -57,17 +57,23 @@ void PrintUsage() {
             << "profile.";
   LOG(INFO) << "If the -j option is given, allow unaligned MMAP events "
             << "required by perf data from VMs with JITs.";
+  LOG(INFO) << "If the -g option is given, saves the profile with sample "
+            << "indices that follow Go's PGO requirements: "
+            << "one of the indices should have the type/unit "
+            << "“samples”/“count” or “cpu”/“nanoseconds”.";
 }
 
 bool ParseArguments(int argc, const char* argv[], std::string* input,
                     std::string* output, bool* overwrite_output,
-                    bool* allow_unaligned_jit_mappings) {
+                    bool* allow_unaligned_jit_mappings,
+                    bool* follow_go_pgo_requirements) {
   *input = "";
   *output = "";
   *overwrite_output = false;
   *allow_unaligned_jit_mappings = false;
+  *follow_go_pgo_requirements = false;
   int opt;
-  while ((opt = getopt(argc, const_cast<char* const*>(argv), ":jfi:o:")) !=
+  while ((opt = getopt(argc, const_cast<char* const*>(argv), ":gjfi:o:")) !=
          -1) {
     switch (opt) {
       case 'i':
@@ -81,6 +87,9 @@ bool ParseArguments(int argc, const char* argv[], std::string* input,
         break;
       case 'j':
         *allow_unaligned_jit_mappings = true;
+        break;
+      case 'g':
+        *follow_go_pgo_requirements = true;
         break;
       case ':':
         LOG(ERROR) << "Must provide arguments for flags -i and -o";

--- a/src/perf_to_profile_lib.h
+++ b/src/perf_to_profile_lib.h
@@ -34,11 +34,12 @@ void CreateFile(const std::string& path, std::ofstream* file,
                 bool overwrite_output);
 
 // Parses arguments, stores the results in |input|, |output|
-// |overwrite_output| and |allow_unaligned_jit_mappings|, and returns true if
+// |overwrite_output|, |allow_unaligned_jit_mappings| and |follow_go_pgo_requirements|, and returns true if
 // arguments parsed successfully and false otherwise.
 bool ParseArguments(int argc, const char* argv[], std::string* input,
                     std::string* output, bool* overwrite_output,
-                    bool* allow_unaligned_jit_mappings);
+                    bool* allow_unaligned_jit_mappings,
+                    bool* follow_go_pgo_requirements);
 
 // Prints the usage of the tool.
 void PrintUsage();

--- a/src/perf_to_profile_lib_test.cc
+++ b/src/perf_to_profile_lib_test.cc
@@ -23,6 +23,7 @@ TEST(PerfToProfileTest, ParseArguments) {
     std::string expected_output;
     bool expected_overwrite_output;
     bool allow_unaligned_jit_mappings;
+    bool follow_go_pgo_requirements;
     bool want_error;
   };
 
@@ -34,6 +35,7 @@ TEST(PerfToProfileTest, ParseArguments) {
       .expected_output = "output_profile",
       .expected_overwrite_output = true,
       .allow_unaligned_jit_mappings = false,
+      .follow_go_pgo_requirements = false,
       .want_error = false});
   tests.push_back(
       Test{.desc = "With input and output flags",
@@ -42,6 +44,7 @@ TEST(PerfToProfileTest, ParseArguments) {
            .expected_output = "output_profile",
            .expected_overwrite_output = false,
            .allow_unaligned_jit_mappings = false,
+           .follow_go_pgo_requirements = false,
            .want_error = false});
   tests.push_back(Test{
       .desc = "With input and output flags and jit-support",
@@ -50,6 +53,7 @@ TEST(PerfToProfileTest, ParseArguments) {
       .expected_output = "output_profile",
       .expected_overwrite_output = false,
       .allow_unaligned_jit_mappings = true,
+      .follow_go_pgo_requirements = false,
       .want_error = false});
   tests.push_back(Test{.desc = "With only overwrite flag",
                        .argv = {"<exec>", "-f"},
@@ -57,6 +61,7 @@ TEST(PerfToProfileTest, ParseArguments) {
                        .expected_output = "",
                        .expected_overwrite_output = false,
                        .allow_unaligned_jit_mappings = false,
+                       .follow_go_pgo_requirements = false,
                        .want_error = true});
   tests.push_back(Test{
       .desc = "With input, output, and invalid flags",
@@ -65,6 +70,7 @@ TEST(PerfToProfileTest, ParseArguments) {
       .expected_output = "",
       .expected_overwrite_output = false,
       .allow_unaligned_jit_mappings = false,
+      .follow_go_pgo_requirements = false,
       .want_error = true});
   tests.push_back(Test{.desc = "With an invalid flag",
                        .argv = {"<exec>", "-F"},
@@ -72,16 +78,18 @@ TEST(PerfToProfileTest, ParseArguments) {
                        .expected_output = "",
                        .expected_overwrite_output = false,
                        .allow_unaligned_jit_mappings = false,
+                       .follow_go_pgo_requirements = false,
                        .want_error = true});
   for (auto test : tests) {
     std::string input;
     std::string output;
     bool overwrite_output;
     bool allow_unaligned_jit_mappings;
+    bool follow_go_pgo_requirements;
     LOG(INFO) << "Testing: " << test.desc;
     EXPECT_THAT(
         ParseArguments(test.argv.size(), test.argv.data(), &input, &output,
-                       &overwrite_output, &allow_unaligned_jit_mappings),
+                       &overwrite_output, &allow_unaligned_jit_mappings, &follow_go_pgo_requirements),
         Eq(!test.want_error));
     if (!test.want_error) {
       EXPECT_THAT(input, Eq(test.expected_input));
@@ -89,6 +97,8 @@ TEST(PerfToProfileTest, ParseArguments) {
       EXPECT_THAT(overwrite_output, Eq(test.expected_overwrite_output));
       EXPECT_THAT(allow_unaligned_jit_mappings,
                   Eq(test.allow_unaligned_jit_mappings));
+      EXPECT_THAT(follow_go_pgo_requirements,
+                  Eq(test.follow_go_pgo_requirements));
     }
     optind = 1;
   }

--- a/src/quipper/perf_parser.h
+++ b/src/quipper/perf_parser.h
@@ -178,6 +178,10 @@ struct PerfParserOptions {
   // Handle unaligned MMAP events emited by VMs that dynamically generate
   // code objects.
   bool allow_unaligned_jit_mappings = false;
+  // The sample indices will be saved following Go's PGO requirements,
+  // with at least one of the indexes having type/unit samples/count
+  // or cpu/nanoseconds. https://go.dev/doc/pgo#alternative-sources
+  bool follow_go_pgo_requirements = false;
 };
 
 class PerfParser {


### PR DESCRIPTION
When converting perf.data, `PerfDataConverter::GetOrCreateBuilder` creates the event name using `event_type.name()`, adding an underscore and saving it in `event_name`. It then sets the type of the sample to `event_name + "sample"` (e.g. "cycles:u_sample").

The problem is that when using the converted perf.data with Go's PGO, it complains that the profile should have at least one of the indices with type/unit of samples/count or cpu/nanoseconds (https://go.dev/doc/pgo#alternative-sources). This adds the -g option to save the sample indices following Go's PGO requirements.