### PR TITLE
Use std::optional for ArmSpeDecoder::Record::source.

### DIFF
--- a/src/quipper/arm_spe_decoder.h
+++ b/src/quipper/arm_spe_decoder.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string_view>
 
 namespace quipper {
@@ -110,7 +111,7 @@ class ArmSpeDecoder {
     RecordPA phys;
     uint64_t timestamp;
     RecordContext context;
-    uint64_t source;
+    std::optional<uint64_t> source;
   };
 
   ArmSpeDecoder(std::string_view buf, bool is_cross_endian);

--- a/src/quipper/arm_spe_decoder_test.cc
+++ b/src/quipper/arm_spe_decoder_test.cc
@@ -146,6 +146,7 @@ TEST(ArmSpeDecoderTest, CorrectlyParseRecords) {
           .virt = {.addr = 0xffff0e3703096b28},
           .timestamp = 44731163950,
           .context = {.id = 0x5f80, .el2 = true},
+          .source = {0},
       }));
 
   EXPECT_TRUE(CheckEqual(


### PR DESCRIPTION
A zero value is perfectly valid, e.g. on Neoverse N1 it means "L1 data cache" (https://developer.arm.com/documentation/100616/0400/debug-descriptions/statistical-profiling-extension/implementation-defined-features-of-spe). Conflating "L1 data cache" and "¯\_(ツ)_/¯" is a bit suboptimal...

PiperOrigin-RevId: 735763823